### PR TITLE
information画面の遷移方法をナビゲーションに置き換える

### DIFF
--- a/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/DetailFragment.kt
+++ b/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/DetailFragment.kt
@@ -6,16 +6,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.Navigation
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.tabs.TabLayoutMediator
+import com.hannibal.replacepraeparet.R
 import com.hannibal.replacepraeparet.model.DetailManager
 import com.hannibal.replacepraeparet.adapter.DetailPagerAdapter
-import com.hannibal.replacepraeparet.model.Flag
 import com.hannibal.replacepraeparet.databinding.FragmentDetailBinding
 
 class DetailFragment : Fragment() {
     private lateinit var binding: FragmentDetailBinding
     private val tabTitleList = listOf("ビザ・渡航", "大使館")
     private val detailManager = DetailManager()
+    private val args: DetailFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -23,25 +26,23 @@ class DetailFragment : Fragment() {
     ): View {
         binding = FragmentDetailBinding.inflate(inflater, container, false)
 
-        val flag = arguments?.getSerializable("country") as Flag
-
         binding.apply {
-            val adapter = DetailPagerAdapter(flag, parentFragmentManager, lifecycle)
+            val adapter = DetailPagerAdapter(args.flag, childFragmentManager, lifecycle)
 
             detailViewPager.adapter = adapter
             TabLayoutMediator(tabLayout, detailViewPager) { tab, position ->
                 tab.text = tabTitleList[position]
             }.attach()
 
-            backButton.setOnClickListener {
-                parentFragmentManager.popBackStack()
-            }
+            backButton.setOnClickListener (
+                Navigation.createNavigateOnClickListener(R.id.action_detailFragment_to_nav_information)
+            )
 
             collapsingToolBar.let {
-                it.title = flag.name
+                it.title = args.flag.name
                 it.setCollapsedTitleTextColor(Color.WHITE)
                 it.setExpandedTitleColor(Color.WHITE)
-                detailManager.setPhoto(eachCountryPhoto, flag.engName)
+                detailManager.setPhoto(eachCountryPhoto, args.flag.engName)
             }
         }
 

--- a/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/DetailVisaFragment.kt
+++ b/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/DetailVisaFragment.kt
@@ -17,7 +17,7 @@ class DetailVisaFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentDetailVisaBinding.inflate(inflater, container, false)
         val flag = arguments?.getSerializable("flag") as Flag
         viewModel.getVisaData(flag.id)

--- a/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/InformationFragment.kt
+++ b/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/InformationFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.tabs.TabLayout
 import com.hannibal.replacepraeparet.*
@@ -66,16 +67,8 @@ class InformationFragment : Fragment() {
         adapter!!.setOnCountryClickListener(
             object : CountriesListAdapter.OnCountryCellClickListener {
                 override fun onItemClick(flag: Flag) {
-                    val fragment = DetailFragment()
-                    val bundle = Bundle()
-                    bundle.putSerializable("country", flag)
-                    fragment.arguments = bundle
-                    parentFragmentManager
-                        .beginTransaction()
-                        .replace(R.id.navHost, fragment)
-                        .addToBackStack(null)
-                        .setReorderingAllowed(true)
-                        .commit()
+                    val action = InformationFragmentDirections.actionNavInformationToDetailFragment(flag)
+                    findNavController().navigate(action)
                 }
             }
         )

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,11 +21,29 @@
         android:id="@+id/nav_information"
         android:name="com.hannibal.replacepraeparet.view.fragment.InformationFragment"
         android:label="fragment_information"
-        tools:layout="@layout/fragment_information" />
+        tools:layout="@layout/fragment_information" >
+
+        <action
+            android:id="@+id/action_nav_information_to_detailFragment"
+            app:destination="@id/detailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_account"
         android:name="com.hannibal.replacepraeparet.view.fragment.AccountFragment"
         android:label="fragment_account"
         tools:layout="@layout/fragment_account" />
+    <fragment
+        android:id="@+id/detailFragment"
+        android:name="com.hannibal.replacepraeparet.view.fragment.DetailFragment"
+        tools:layout="@layout/fragment_detail"
+        android:label="DetailFragment" >
+
+        <action
+            android:id="@+id/action_detailFragment_to_nav_information"
+            app:popUpTo="@id/nav_information" />
+        <argument
+            android:name="flag"
+            app:argType="com.hannibal.replacepraeparet.model.Flag" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
・対処内容
information画面の遷移方法をナビゲーションに置き換える

・具体的な対処内容
view\fragment\DetailFragment.kt
遷移先に送る値を取得
```
private val args: DetailFragmentArgs by navArgs()
val adapter = DetailPagerAdapter(args.flag, childFragmentManager, lifecycle)
```
詳細画面から戻るボタンを押下時の処理
```
backButton.setOnClickListener (
Navigation.createNavigateOnClickListener(R.id.action_detailFragment_to_nav_information)
)
```
詳細画面に表示する文言をargsから取得
```
it.title = args.flag.name
detailManager.setPhoto(eachCountryPhoto, args.flag.engName)
```

view\fragment\InformationFragment.kt
FragmentManagerからNavigationへ置き換える
```
val action = InformationFragmentDirections.actionNavInformationToDetailFragment(flag)
findNavController().navigate(action)
```

res\navigation\nav_graph.xml
24行目～
```
tools:layout="@layout/fragment_information" >

<action
    android:id="@+id/action_nav_information_to_detailFragment"
    app:destination="@id/detailFragment" />
</fragment>
<fragment
android:id="@+id/detailFragment"
android:name="com.hannibal.replacepraeparet.view.fragment.DetailFragment"
tools:layout="@layout/fragment_detail"
android:label="DetailFragment" >

<action
    android:id="@+id/action_detailFragment_to_nav_information"
    app:popUpTo="@id/nav_information" />
<argument
    android:name="flag"
    app:argType="com.hannibal.replacepraeparet.model.Flag" />
</fragment>
```


・確認内容
動作に問題がないことなど