### PR TITLE
アカウント画面のログインボタンをログイン状態によって変更させるように修正

### DIFF
--- a/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/AccountFragment.kt
+++ b/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/AccountFragment.kt
@@ -5,10 +5,10 @@ import android.content.ContentValues
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.IdpResponse
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -22,12 +22,15 @@ class AccountFragment : Fragment() {
     private lateinit var binding: FragmentAccountBinding
     private val tabTitleList = listOf("投稿", "写真", "投稿位置")
     val SIGN_IN_RESULT_CODE = 9999
+    private lateinit var auth: FirebaseAuth
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
         binding = FragmentAccountBinding.inflate(inflater, container, false)
+
+        auth = FirebaseAuth.getInstance()
 
         binding.apply {
             val adapter = AccountPagerAdapter(childFragmentManager, lifecycle)
@@ -43,8 +46,20 @@ class AccountFragment : Fragment() {
                     .setAllCornerSizes(ShapeAppearanceModel.PILL)
                     .build()
 
-            loginButton.setOnClickListener {
-                launchSignInFlow()
+            auth.addAuthStateListener { mAuth ->
+                if (mAuth.currentUser != null) {
+                    loginButton.text = "ログアウト"
+                    loginButton.setOnClickListener {
+                        mAuth.signOut()
+                        Log.d("LoginState", "ログアウトしました。")
+                    }
+                } else {
+                    loginButton.text = "ログイン"
+                    loginButton.setOnClickListener {
+                        launchSignInFlow()
+                        Log.d("LoginState", "ログインしました。")
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
・対処内容
アカウント画面のログインボタンをログイン状態によって変更させるように修正

・具体的な対処内容
view\fragment\AccountFragment.kt
25行目
`private lateinit var auth: FirebaseAuth`
33行目
`auth = FirebaseAuth.getInstance()`
49~62行目
```
auth.addAuthStateListener { mAuth ->
    if (mAuth.currentUser != null) {
        loginButton.text = "ログアウト"
        loginButton.setOnClickListener {
            mAuth.signOut()
            Log.d("LoginState", "ログアウトしました。")
        }
    } else {
        loginButton.text = "ログイン"
        loginButton.setOnClickListener {
            launchSignInFlow()
            Log.d("LoginState", "ログインしました。")
        }
    }
```

・確認内容
アカウント画面のボタンの表記が変わり、動作に問題がないことなど