### PR TITLE
ボトムシートにある入力欄の余白を追加する

### DIFF
--- a/app/src/main/res/layout/fragment_post_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_post_bottom_sheet.xml
@@ -106,8 +106,9 @@
             android:hint="@string/title_text_hint"
             android:minHeight="30dp"
             android:textSize="18dp"
-            android:gravity="center"
+            android:gravity="top|left"
             android:layout_marginTop="8dp"
+            android:padding="8dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/title_label" />
 
@@ -192,6 +193,8 @@
             android:layout_width="match_parent"
             android:layout_height="100dp"
             android:layout_marginTop="8dp"
+            android:padding="8dp"
+            android:gravity="top|left"
             android:background="@drawable/bg_edittext"
             app:layout_constraintStart_toStartOf="@id/address_label"
             app:layout_constraintTop_toBottomOf="@id/address_label" />
@@ -262,6 +265,9 @@
             android:layout_width="match_parent"
             android:layout_height="100dp"
             android:layout_marginTop="8dp"
+            android:padding="8dp"
+            android:hint="@string/enter_text"
+            android:gravity="top|left"
             android:background="@drawable/bg_edittext"
             app:layout_constraintStart_toStartOf="@id/comment_label"
             app:layout_constraintTop_toBottomOf="@id/comment_label" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,5 @@
     <string name="title_text_hint">タイトルを入力...</string>
     <string name="specific_position">特定位置</string>
     <string name="choose_image_alert_text">写真は５枚まで選択できます。</string>
+    <string name="enter_text">文章を入力...</string>
 </resources>


### PR DESCRIPTION
・対処内容
ボトムシートにある入力欄の余白を追加するように修正

・具体的な対処内容
各入力欄に以下の２行を追加
res/layout/fragment_post_bottom_sheet.xml
```
android:gravity="top|left"
android:padding="8dp"
```

hintに表示するテキストを記載
res/values/strings.xml
`<string name="enter_text">文章を入力...</string>`

・確認内容
表記に問題がないことなど
