### PR TITLE
探す画面のレイアウトを作成

### DIFF
--- a/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/hannibal/replacepraeparet/view/fragment/SearchFragment.kt
@@ -5,16 +5,29 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.hannibal.replacepraeparet.R
 import com.hannibal.replacepraeparet.databinding.FragmentSearchBinding
 
-class SearchFragment : Fragment() {
+class SearchFragment : Fragment(), OnMapReadyCallback {
     private lateinit var binding: FragmentSearchBinding
+    private lateinit var mMap: GoogleMap
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
         binding = FragmentSearchBinding.inflate(inflater, container, false)
+
+        val mapFragment = childFragmentManager.findFragmentById(R.id.map_fragment) as SupportMapFragment
+        mapFragment.getMapAsync(this)
+
         return binding.root
+    }
+
+    override fun onMapReady(googleMap: GoogleMap) {
+        mMap = googleMap
     }
 }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".view.fragment.SearchFragment">
 
-    <TextView
+    <fragment
+        android:id="@+id/map_fragment"
+        class="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="hello_search_fragment" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
・対処内容
〇〇の不具合修正

・具体的な対処内容
view\fragment\SearchFragment.kt
Fragmentに OnMapReadyCallbackを設定し、マップを生成する
```
class SearchFragment : Fragment(), OnMapReadyCallback {
    private lateinit var mMap: GoogleMap
　...
}
override fun onMapReady(googleMap: GoogleMap) {
    mMap = googleMap
}
```
OnCreateView内に定義
```
val mapFragment = childFragmentManager.findFragmentById(R.id.map_fragment) as SupportMapFragment
mapFragment.getMapAsync(this)
```

src\main\res\layout\fragment_search.xml
GoogleMapを設置するフラグメントを定義
<fragment
    android:id="@+id/map_fragment"
    class="com.google.android.gms.maps.SupportMapFragment"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    app:layout_constraintStart_toStartOf="parent"
    app:layout_constraintTop_toTopOf="parent"
    app:layout_constraintEnd_toEndOf="parent"
    app:layout_constraintBottom_toBottomOf="parent" />

・確認内容
表記に問題がないことなど